### PR TITLE
Posting Authority check before logging in

### DIFF
--- a/src/repositories/hive/hive.repository.ts
+++ b/src/repositories/hive/hive.repository.ts
@@ -149,7 +149,7 @@ export class HiveRepository {
     )
   }
 
-  async doWeHavePostingAuth(account: any) {
+  async verifyPostingAuth(account: any) {
     let doWe = false
     if (Array.isArray(account.posting.account_auths)) {
       account.posting.account_auths.forEach(function (item) {

--- a/src/services/auth/auth.controller.ts
+++ b/src/services/auth/auth.controller.ts
@@ -63,7 +63,7 @@ export class AuthController {
         this.hiveRepository.verifyHiveMessage(cryptoUtils.sha256(JSON.stringify(proof_payload)), body.proof, accountDetails) &&
         new Date(proof_payload.ts) > moment().subtract('1', 'minute').toDate() //Extra safety to prevent request reuse
       ) {
-        if (this.hiveRepository.doWeHavePostingAuth(accountDetails)) {
+        if (this.hiveRepository.verifyPostingAuth(accountDetails)) {
           return await this.authService.authenticateUser(proof_payload.account)
         } else {
           throw new HttpException(


### PR DESCRIPTION
- Granting JWT Token only if posting authority found. 
- This JWT Token subsequently will be used for upvote, comment, post etc.
- Without posting authority, all of the operations may fail.
- So, it's best to check at time of login `/login_singleton`
- It would be front-ends responsibility to get posting authority first.
- After that front-ends can generate proof & proof of payload & execute`/login_singleton` for logging in.