### PR TITLE
Add vscode config to source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ logs
 dist
 
 .env*
-.vscode
 data
 .DS_Store

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "eamodio.gitlens",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "mikestead.dotenv",
+    "formulahendry.auto-rename-tag"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
     "mikestead.dotenv",
-    "formulahendry.auto-rename-tag"
+    "formulahendry.auto-rename-tag",
+    "orta.vscode-jest"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to Docker",
+      "port": 9229,
+      "address": "localhost",
+      "localRoot": "${workspaceFolder}",
+      "remoteRoot": "/usr/app",
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to Docker",
+      "port": 9229,
+      "address": "localhost",
+      "localRoot": "${workspaceFolder}",
+      "remoteRoot": "/usr/app",
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}


### PR DESCRIPTION
Including the vscode config in the source allows us to create a reproducible dev environment between contributors. This configuration includes:
- a configuration for debugging acela-core while it's running in docker
- recommended plugins for this workspace (eslint, prettier, gitlens, dotenv, auto rename tag)