### PR TITLE
Email password signup

### DIFF
--- a/src/repositories/user/schemas/user.schema.ts
+++ b/src/repositories/user/schemas/user.schema.ts
@@ -10,13 +10,13 @@ export class LegacyUser {
   @Prop({ type: String, required: true })
   user_id!: string;
 
-  @Prop({ type: String, unique: true })
+  @Prop({ type: String, unique: true, sparse: true })
   sub?: string;
 
   @Prop({ type: Boolean, required: true, default: false })
   banned?: boolean;
 
-  @Prop({ type: String })
+  @Prop({ type: String, unique: true, sparse: true })
   email?: string;
 
   @Prop({ type: Types.ObjectId, ref: LegacyHiveAccount.name })

--- a/src/repositories/userAccount/schemas/user-account.schema.ts
+++ b/src/repositories/userAccount/schemas/user-account.schema.ts
@@ -6,13 +6,13 @@ export type LegacyUserDocument = mongoose.Document & LegacyUserAccount;
 
 @Schema()
 export class LegacyUserAccount {
-  @Prop({ type: String, required: false })
+  @Prop({ type: String, default: () => uuid() })
   confirmationCode?: string;
 
   @Prop({ type: Date, required: true, default: new Date() })
   createdAt?: Date;
 
-  @Prop({ type: String })
+  @Prop({ type: String, unique: true, sparse: true })
   email?: string;
 
   @Prop({ type: Boolean, required: true, default: false })

--- a/src/services/api/api.controller.ts
+++ b/src/services/api/api.controller.ts
@@ -253,20 +253,17 @@ export class ApiController {
   @Post(`/hive/vote`)
   async votePost(@Body() data: VotePostDto, @Request() req: any) {
     const parsedRequest = parseAndValidateRequest(req, this.#logger);
-    const { author, permlink, weight, votingAccount } = data;
-
-    const user = await this.authService.getUserByUserId({ user_id: parsedRequest.user.user_id });
-
-    if (!user) throw new UnauthorizedException('User not found');
+    const votingAccount = await this.hiveService.parseHiveUsername(
+      parsedRequest,
+      data.votingAccount,
+    );
+    const { author, permlink, weight } = data;
 
     return await this.hiveService.vote({
-      sub: parsedRequest.user.sub,
       votingAccount,
       author,
       permlink,
       weight,
-      network: parsedRequest.user.network,
-      user_id: user._id,
     });
   }
 }

--- a/src/services/auth/auth.controller.test.ts
+++ b/src/services/auth/auth.controller.test.ts
@@ -203,7 +203,7 @@ describe('AuthController', () => {
         .send({ email, password })
         .expect(201);
 
-      expect(response.body).toEqual({ ok: true });
+      expect(response.body).toEqual({ access_token: expect.any(String) });
 
       const user = await userRepository.findOneByEmail(email);
       expect(user).toBeDefined();

--- a/src/services/auth/auth.controller.test.ts
+++ b/src/services/auth/auth.controller.test.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config'
 import { UserAccountModule } from '../../repositories/userAccount/user-account.module';
 import { SessionModule } from '../../repositories/session/session.module';
 import { AuthController } from './auth.controller';
@@ -19,12 +18,15 @@ import { Ed25519Provider } from 'key-did-provider-ed25519';
 import { INestApplication, Module, ValidationPipe } from '@nestjs/common';
 import * as KeyResolver from 'key-did-resolver';
 import { TestingModule } from '@nestjs/testing';
-import crypto from 'crypto';
+import crypto, { randomUUID } from 'crypto';
 import { PrivateKey } from '@hiveio/dhive';
 import { AuthGuard } from '@nestjs/passport';
 import { MockAuthGuard, MockDidUserDetailsInterceptor, UserDetailsInterceptor } from '../api/utils';
 import { HiveService } from '../hive/hive.service';
 import { HiveModule } from '../hive/hive.module';
+import { LegacyUserRepository } from '../../repositories/user/user.repository';
+import { EmailService } from '../email/email.service';
+import { LegacyUserAccountRepository } from '../../repositories/userAccount/user-account.repository';
 
 describe('AuthController', () => {
   let app: INestApplication
@@ -35,11 +37,13 @@ describe('AuthController', () => {
   let mongod: MongoMemoryServer;
   let authService: AuthService;
   let hiveService: HiveService;
-
+  let userRepository: LegacyUserRepository;
+  let emailService: EmailService;
+  let userAccountRepository: LegacyUserAccountRepository;
 
   beforeEach(async () => {
-    mongod = await MongoMemoryServer.create()
-    const uri: string = mongod.getUri()
+    mongod = await MongoMemoryServer.create();
+    const uri: string = mongod.getUri();
 
     process.env.JWT_PRIVATE_KEY = crypto.randomBytes(64).toString('hex');
     process.env.DELEGATED_ACCOUNT = 'threespeak';
@@ -88,21 +92,24 @@ describe('AuthController', () => {
     })
     class TestModule {}
 
-    let moduleRef: TestingModule;
-
-    moduleRef = await Test.createTestingModule({
+    let moduleRef = await Test.createTestingModule({
       imports: [TestModule],
     }).overrideGuard(AuthGuard('jwt'))
       .useClass(MockAuthGuard)
       .overrideInterceptor(UserDetailsInterceptor)
       .useClass(MockDidUserDetailsInterceptor)
       .compile();
+    
     authService = moduleRef.get<AuthService>(AuthService);
     hiveService = moduleRef.get<HiveService>(HiveService);
+    userRepository = moduleRef.get<LegacyUserRepository>(LegacyUserRepository);
+    userAccountRepository = moduleRef.get<LegacyUserAccountRepository>(LegacyUserAccountRepository);
+    emailService = moduleRef.get<EmailService>(EmailService);
+
     app = moduleRef.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
-    await app.init()
-  })
+    await app.init();
+  });
 
   afterEach(async () => {
     await app.close();
@@ -183,7 +190,78 @@ describe('AuthController', () => {
           expect(await hiveService.isHiveAccountLinked({ account: 'bob', user_id: user._id })).toBe(true)
           expect(await hiveService.isHiveAccountLinked({ account: username, user_id: user._id })).toBe(false)
         });
+      });
+  });
+
+  describe('/POST register', () => {
+    it('registers a new user successfully with valid email', async () => {
+      const email = 'test@invalid.example.org';
+      const password = '!SUPER-SECRET_password!7';
+
+      const response = await request(app.getHttpServer())
+        .post('/v1/auth/register')
+        .send({ email, password })
+        .expect(201);
+
+      expect(response.body).toEqual({ ok: true });
+
+      const user = await userRepository.findOneByEmail(email);
+      expect(user).toBeDefined();
     });
+
+    it('throws error when email is already registered', async () => {
+      const email = 'test@invalid.example.org';
+      const password = '!SUPER-SECRET_password!7';
+      
+      // Create a user with the same email
+      await authService.createEmailAndPasswordUser(email, password, randomUUID());
+
+      return request(app.getHttpServer())
+        .post('/v1/auth/register')
+        .send({ email, password })
+        .expect(400)
+        .then(response => {
+          expect(response.body).toEqual({ reason: 'Email Password account already created!' });
+        });
+    });
+
+    it('throws error when email is invalid', async () => {
+      const email = 'tesnvalid.example.org';
+      const password = '!SUPER-SECRET_password!7';
+
+      return request(app.getHttpServer())
+        .post('/v1/auth/register')
+        .send({ email, password })
+        .expect(400)
+        .then(response => {
+          expect(response.body).toEqual({
+            error: "Bad Request",
+            message: [
+              "Email must be a valid email address",
+              "email must be an email",
+            ],
+            statusCode: 400
+          });
+        });
+    });
+
+    it('throws error when password is not strong enough', async () => {
+      const email = 'test@invalid.example.org';
+      const password = '!SUPER-SECRET_password!';
+
+      return request(app.getHttpServer())
+        .post('/v1/auth/register')
+        .send({ email, password })
+        .expect(400)
+        .then(response => {
+          expect(response.body).toEqual({
+            error: "Bad Request",
+            message: [
+              "password is not strong enough",
+            ],
+            statusCode: 400
+          });
+        });
   });
   
 
@@ -308,6 +386,7 @@ describe('AuthController', () => {
             statusCode: 401,
           })
         })
+      })
     })
   })
 });

--- a/src/services/auth/auth.controller.ts
+++ b/src/services/auth/auth.controller.ts
@@ -45,6 +45,7 @@ import { HiveService } from '../hive/hive.service';
 import { AuthInterceptor, UserDetailsInterceptor } from '../api/utils';
 import { randomUUID } from 'crypto';
 import { v4 as uuid } from 'uuid';
+import { EmailRegisterDto } from './dto/EmailRegister.dto';
 
 @Controller('/v1/auth')
 export class AuthController {
@@ -308,18 +309,7 @@ export class AuthController {
     summary: 'Registers an account using email/password login',
   })
   @ApiBody({
-    schema: {
-      properties: {
-        password: {
-          type: 'string',
-          default: '!SUPER-SECRET_PASSWORD!',
-        },
-        email: {
-          type: 'string',
-          default: 'test@invalid.example.org',
-        },
-      },
-    },
+    type: EmailRegisterDto,
   })
   @ApiOkResponse({
     schema: {
@@ -331,9 +321,28 @@ export class AuthController {
       },
     },
   })
+  @ApiBadRequestResponse({
+    description: 'Invalid options or email already registered',
+    schema: {
+      type: 'object',
+      properties: {
+        reason: {
+          type: 'string',
+          default: 'Invalid email or password',
+        },
+        errorType: {
+          type: 'string',
+          default: 'VALIDATION_ERROR',
+        },
+      },
+    },
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal Server Error - unrelated to request body',
+  })
   // @UseGuards(AuthGuard('local'))
   @Post('/register')
-  async register(@Request() req, @Body() body: { password: string; email: string }) {
+  async register(@Body() body: EmailRegisterDto) {
     const { email, password } = body;
 
     const existingRecord = await this.userRepository.findOneByEmail(email);
@@ -353,7 +362,6 @@ export class AuthController {
     return {
       ok: true,
     };
-    // return this.authService.login(req.user);
   }
 
   @ApiParam({

--- a/src/services/auth/auth.controller.ts
+++ b/src/services/auth/auth.controller.ts
@@ -349,9 +349,8 @@ export class AuthController {
     const email_code = await this.authService.createEmailAndPasswordUser(email, password, user_id);
 
     await this.emailService.sendRegistration(email, email_code);
-    return {
-      ok: true,
-    };
+
+    return await this.authService.login({ network: 'email', user_id });
   }
 
   @ApiParam({

--- a/src/services/auth/auth.controller.ts
+++ b/src/services/auth/auth.controller.ts
@@ -344,16 +344,6 @@ export class AuthController {
   @Post('/register')
   async register(@Body() body: EmailRegisterDto) {
     const { email, password } = body;
-
-    const existingRecord = await this.userRepository.findOneByEmail(email);
-
-    if (existingRecord) {
-      throw new HttpException(
-        { reason: 'Email Password account already created!' },
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
     const user_id = uuid();
 
     const email_code = await this.authService.createEmailAndPasswordUser(email, password, user_id);

--- a/src/services/auth/auth.types.ts
+++ b/src/services/auth/auth.types.ts
@@ -7,7 +7,7 @@ export const accountTypes = ['singleton', 'lite'] as const;
 export type AccountType = (typeof accountTypes)[number];
 
 const userSchema = z.object({
-  sub: z.string(),
+  sub: z.string().optional(),
   network: z.enum(network),
   type: z.enum(accountTypes).optional(),
   user_id: z.string(),

--- a/src/services/auth/dto/EmailRegister.dto.ts
+++ b/src/services/auth/dto/EmailRegister.dto.ts
@@ -1,0 +1,20 @@
+import { IsEmail, IsNotEmpty, IsStrongPassword, Matches } from 'class-validator';
+
+export class EmailRegisterDto {
+  @IsEmail()
+  @Matches(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/, {
+    message: 'Email must be a valid email address',
+  })
+  @IsNotEmpty()
+  email: string;
+
+  @IsStrongPassword({
+    minLength: 7,
+    minLowercase: 1,
+    minUppercase: 1,
+    minNumbers: 1,
+    minSymbols: 1,
+  })
+  @IsNotEmpty()
+  password: string;
+}

--- a/src/services/uploader/uploading.controller.test.ts
+++ b/src/services/uploader/uploading.controller.test.ts
@@ -9,8 +9,6 @@ import { UploadingModule } from './uploading.module';
 import request from 'supertest';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { INestApplication, Module, ValidationPipe } from '@nestjs/common';
-import * as fs from 'fs';
-import * as path from 'path';
 import { AuthGuard } from '@nestjs/passport';
 import { UploadModule } from '../../repositories/upload/upload.module';
 import { VideoModule } from '../../repositories/video/video.module';

--- a/src/services/uploader/uploading.controller.test.ts
+++ b/src/services/uploader/uploading.controller.test.ts
@@ -232,7 +232,7 @@ describe('UploadingController', () => {
         .then(response => {
           expect(response.body).toEqual({
             error: "Unauthorized",
-            message: "Your account is not linked to the requested hive account",
+            message: "Hive account is not linked",
             statusCode: 401,
           });
         });
@@ -287,7 +287,7 @@ describe('UploadingController', () => {
         .then(response => {
           expect(response.body).toEqual({
             error: "Unauthorized",
-            message: "Your account is not linked to the requested hive account",
+            message: "Hive account is not linked",
             statusCode: 401,
           });
         });

--- a/src/services/uploader/uploading.service.ts
+++ b/src/services/uploader/uploading.service.ts
@@ -50,7 +50,7 @@ export class UploadingService {
     username,
     user_id,
   }: {
-    sub: string;
+    sub?: string;
     username: string;
     user_id: string;
   }) {


### PR DESCRIPTION
- create email and password registration, along with tests and a dto for validation
- made sub completely optional, its now more like email address only used to find accounts, not for authentication
- did some refactoring, particularly in regard to hive username validation
- moved uniqueness validation for USB and email to the datalayer